### PR TITLE
Exp: modify isReadOnly to support more read cases 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log*
 
 # misc
 .DS_Store
+.eslintcache

--- a/src/StateSnapshot.js
+++ b/src/StateSnapshot.js
@@ -1,8 +1,10 @@
 import {
   callExpressions,
   functionTypes,
-  getParentOfNodeType,
-  isInHookDeps,
+  isDepthSameAsRootComponent,
+  isInCustomHookDef,
+  isInReactHookDeps,
+  isInReactHooks,
   isInSomething,
   isReadOnly,
 } from './lib/utils'
@@ -79,8 +81,9 @@ export default {
         if (
           node.parent.type === 'MemberExpression' &&
           node.parent.property === node
-        )
+        ) {
           return
+        }
 
         const kind = which(node.name, scope)
         if (kind === 'state' && isInRender(node)) {
@@ -94,16 +97,35 @@ export default {
           // ignore the error if the snapshot
           // is just being read in the hook and is a part of the dependency array
 
-          if (
-            isReadOnly(node) &&
-            (isInHookDeps(node) ||
+          // Valids
+          // - allowed to read at root level for computation (new hook / render level defs) , basically anything defined at the root of the component definition
+          // [x] allowed to read in a useEffect and useCallback if added in deps
+
+          // Invalids
+          // [x] if being used in a callback that isn't useEffect or useCallback
+
+          if (isReadOnly(node)) {
+            if (isInReactHooks(node) && !isInReactHookDeps(node)) {
+              return context.report({
+                node,
+                message: SNAPSHOT_CALLBACK_MESSAGE,
+              })
+            }
+            if (
+              isDepthSameAsRootComponent(node) ||
               isInJSXContainer(node) ||
-              isInDeclaration(node))
-          ) {
-            return
+              isInCustomHookDef(node)
+            ) {
+              return
+            }
+          } else {
+            return context.report({
+              node,
+              message: SNAPSHOT_CALLBACK_MESSAGE,
+            })
           }
 
-          if (isInCallback(node)) {
+          if (isInCallback(node) && !isInReactHooks(node)) {
             return context.report({
               node,
               message: SNAPSHOT_CALLBACK_MESSAGE,
@@ -218,8 +240,9 @@ function isComputedIdentifier(node, scope) {
     }
   })
 
-  if (!isIt && scope.upper)
+  if (!isIt && scope.upper) {
     return (isIt = isComputedIdentifier(node, scope.upper))
+  }
 
   return isIt
 }
@@ -324,8 +347,9 @@ function isUsedInUseProxy(node, scope) {
       }
     }
   })
-  if (!isUsed && scope.upper)
+  if (!isUsed && scope.upper) {
     return (isUsed = isUsedInUseProxy(node, scope.upper))
+  }
   return isUsed
 }
 
@@ -371,12 +395,12 @@ function isInJSXContainer(node) {
   )
 }
 
-function isInDeclaration(node) {
-  const _parentDeclaration = getParentOfNodeType(node, 'VariableDeclarator')
+// function isInDeclaration(node) {
+//   const _parentDeclaration = getParentOfNodeType(node, 'VariableDeclarator')
 
-  if (_parentDeclaration?.init?.callee?.name === 'useSnapshot') {
-    return true
-  }
+//   if (_parentDeclaration?.init?.callee?.name === 'useSnapshot') {
+//     return true
+//   }
 
-  return false
-}
+//   return false
+// }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -16,7 +16,6 @@ export const writingOpExpressionTypes = ['UpdateExpression']
  *
  *  isInSomething(thisNode,"FunctionExpression") // true
  *  isInSomething(thisNode,"ExpressionStatement") // false
- *
  */
 export function isInSomething(node, thing) {
   if (node.parent && node.parent.type !== thing) {
@@ -30,10 +29,9 @@ export function isInSomething(node, thing) {
 /**
  * @param {any} node ASTNode
  *
- *
  * @example
  *
- *const stateOne = proxy({
+ * const stateOne = proxy({
  * count: 0,
  * inc: function () {
  *   ++state.count //<== taking node from here
@@ -41,7 +39,6 @@ export function isInSomething(node, thing) {
  * })
  *
  * nearestCalleeName(node) //=> "proxy" //<= proxy is the nearest callee
- *
  */
 export function nearestCalleeName(node) {
   if (!(node && node.parent)) {
@@ -81,9 +78,12 @@ export function nearestCalleeName(node) {
  *
  *  getParentOfNodeType(thisNode,"FunctionExpression") // ASTNode.type: "FunctionExpression"
  *  getParentOfNodeType(thisNode,"ExpressionStatement") // null
- *
  */
 export function getParentOfNodeType(node, nodeType) {
+  if (!node?.parent) {
+    return null
+  }
+
   if (node.parent && node.parent.type !== nodeType) {
     return getParentOfNodeType(node.parent, nodeType)
   } else if (node.parent && node.parent.type === nodeType) {
@@ -111,11 +111,14 @@ export function isReadOnly(node) {
     return isReadOnly(node.parent)
   }
 
+  if (node.parent.type === 'CallExpression') {
+    return true
+  }
+
   return true
 }
 
 /**
- *
  * @param {*} node
  * @returns {boolean} true if the node is on the left
  * of an assignment expression aka being modified
@@ -152,7 +155,7 @@ export function returnFirstCallback(node) {
  * resulting node or not
  * @returns {* | boolean} - either true/false or the CallExpression node that belongs to the hook
  */
-export function isInHook(node, returnHook = false) {
+export function isInReactHooks(node, returnHook = false) {
   const hookDef = getNearestHook(node)
   if (returnHook) {
     return hookDef
@@ -160,20 +163,35 @@ export function isInHook(node, returnHook = false) {
   return hookDef ? true : false
 }
 
+function isReactPrimitive(node) {
+  if (
+    node.type === 'Identifier' &&
+    (node.name === 'useEffect' || node.name === 'useCallback')
+  ) {
+    return true
+  }
+
+  if (node.type === 'MemberExpression') {
+    const flatExpr = flattenMemberExpression(node)
+    return flatExpr.endsWith('useEffect') || flatExpr.endsWith('useCallback')
+  }
+
+  return false
+}
+
 export function getNearestHook(node) {
   if (!node.parent || !node.parent.type) return false
 
-  if (
-    functionTypes.includes(node.type) &&
-    node.parent.type == 'CallExpression' &&
-    node.parent.callee.type === 'Identifier' &&
-    (node.parent.callee.name === 'useEffect' ||
-      node.parent.callee.name === 'useCallback')
-  ) {
-    return node.parent
-  } else {
-    return getNearestHook(node.parent)
+  const parentCaller = getParentOfNodeType(node, 'CallExpression')
+  if (!parentCaller) {
+    return false
   }
+
+  if (!isReactPrimitive(parentCaller.callee)) {
+    return getNearestHook(parentCaller)
+  }
+
+  return parentCaller
 }
 
 /**
@@ -182,8 +200,8 @@ export function getNearestHook(node) {
  * @param {*} node
  * @returns {boolean}
  */
-export function isInHookDeps(node) {
-  const hookNode = isInHook(node, true)
+export function isInReactHookDeps(node) {
+  const hookNode = isInReactHooks(node, true)
   if (!hookNode) {
     return false
   }
@@ -267,4 +285,56 @@ function flattenMemberExpression(expr, key = '') {
     }
     return path
   }
+}
+
+export function isDepthSameAsRootComponent(node) {
+  const varDef = getParentOfNodeType(node, 'VariableDeclaration')
+  const parentNormalFunc = getParentOfNodeType(varDef, 'FunctionDeclaration')
+  const parentArrFunc = getParentOfNodeType(varDef, 'ArrowFunctionExpression')
+
+  const parentFunc = parentNormalFunc || parentArrFunc
+  if (!parentFunc) {
+    return false
+  }
+
+  if (
+    parentFunc?.parent.type === 'VariableDeclarator' &&
+    parentFunc?.parent.parent.type === 'VariableDeclaration' &&
+    parentFunc?.parent.parent.parent.type === 'Program'
+  ) {
+    return true
+  }
+}
+
+export function isInCustomHookDef(node) {
+  const nearestReturn = getParentOfNodeType(node, 'ReturnStatement')
+  const returnInBlock = getParentOfNodeType(nearestReturn, 'BlockStatement')
+  const normalFuncDef = getParentOfNodeType(
+    returnInBlock,
+    'ArrowFunctionExpression'
+  )
+  const arrowFuncDef = getParentOfNodeType(returnInBlock, 'FunctionExpression')
+
+  const nearestFuncDef = normalFuncDef || arrowFuncDef || false
+
+  if (!nearestFuncDef) {
+    return false
+  }
+
+  const varDeclaratorOfFunc = getParentOfNodeType(
+    nearestFuncDef,
+    'VariableDeclarator'
+  )
+  const varDefOfFunc = getParentOfNodeType(
+    varDeclaratorOfFunc,
+    'VariableDeclaration'
+  )
+
+  const varDefOnRoot = varDefOfFunc.parent?.type === 'Program' || false
+
+  return (
+    varDefOnRoot &&
+    varDeclaratorOfFunc.id?.type === 'Identifier' &&
+    varDeclaratorOfFunc.id?.name.startsWith('use')
+  )
 }

--- a/tests/StateSnapshot.test.js
+++ b/tests/StateSnapshot.test.js
@@ -14,307 +14,352 @@ const ruleTester = new RuleTester({
 ruleTester.run('state-snapshot-rule', rule, {
   valid: [
     `
-      const state = proxy({ count: 0 })
-      state.count += 1
-      `,
+         const state = proxy({ count: 0 })
+         state.count += 1
+         `,
     `
-      const state = proxy({ count: 0})
-      function Counter() {
-        return (
-          <div>
-            <button onClick={() => ++state.count}>+1</button>
-          </div>
-        )
-      }
-      `,
+         const state = proxy({ count: 0})
+         function Counter() {
+           return (
+             <div>
+               <button onClick={() => ++state.count}>+1</button>
+             </div>
+           )
+         }
+         `,
     `
-      function Counter() {
-        const snapshot = useSnapshot(state)
-        const { count } = snapshot
-        return (
-          <div>{count} {snapshot.count}</div>
-        )
-      }
-      `,
+         function Counter() {
+           const snapshot = useSnapshot(state)
+           const { count } = snapshot
+           return (
+             <div>{count} {snapshot.count}</div>
+           )
+         }
+         `,
     `
-      function Counter() {
-        const { count } = useSnapshot(state)
-        return <div>{count}</div>
-      }
-      `,
+         function Counter() {
+           const { count } = useSnapshot(state)
+           return <div>{count}</div>
+         }
+         `,
     `
-      function Counter() {
-        const snap = useSnapshot(state)
-        useEffect(() => {
-          state.count += 1
-        }, [])
-        return <div>{snap.foo}</div>
-      }
-      `,
+         function Counter() {
+           const snap = useSnapshot(state)
+           useEffect(() => {
+             state.count += 1
+           }, [])
+           return <div>{snap.foo}</div>
+         }
+         `,
     `
-    function useExample2(s) {
-      const {b: {c} } = useSnapshot(s.a1);
+       function useExample2(s) {
+         const {b: {c} } = useSnapshot(s.a1);
+    
+         useEffect(() => {
+           if (c === 'a1c') {
+             state.a1.b.c = 'example';
+           }
+         }, [c]);
+       }`,
 
-      useEffect(() => {
-        if (c === 'a1c') {
-          state.a1.b.c = 'example';
-        }
-      }, [c]);
-    }`,
-
     `
-    function useProxyStateExample(a) {
-      const s = useSnapshot(a);
-
-      useEffect(() => {
-          a.a = 'example';
-      }, [s.a]);
-    }`,
+       function useProxyStateExample(a) {
+         const s = useSnapshot(a);
+    
+         useEffect(() => {
+             a.a = 'example';
+         }, [s.a]);
+       }`,
     `const state = proxy({ count: 0 });
-    function App() {
-      const snap = useSnapshot(state);
-      const handleClick = useCallback(() => {
-        console.log(snap.count);
-      }, [snap.count]);
-      return (
-        <div>
-          {snap.count} <button onClick={handleClick}>click</button>
-        </div>
-      );
+       function App() {
+         const snap = useSnapshot(state);
+         const handleClick = useCallback(() => {
+           console.log(snap.count);
+         }, [snap.count]);
+         return (
+           <div>
+             {snap.count} <button onClick={handleClick}>click</button>
+           </div>
+         );
+       }
+       `,
+    `
+       const DirectReadComponent = () => {
+         const debounceSnap = useSnapshot(state);
+         return <div>{debounceSnap}</div>;
+       };
+       `,
+    `
+       const ObjectPatternReadOne = () => {
+         const {b: {c} } = useSnapshot(state);
+         return <div>{c}</div>;
+       };`,
+    `
+       const ObjectPatternReadTwo = () => {
+         const {c} = useSnapshot(state);
+         return <div>{c}</div>;
+       };`,
+    `
+     const state = proxy({ count: 1 })
+     const useDoubled = () => {
+       const snap = useSnapshot(state)
+       return snap.count * 2
+     }
+     const Component = ()=> {
+       const doubled = useDoubled()
+       return <>{doubled}</>
+     }
+      `,
+    `
+    const Component = ()=>{
+      const { index } = useSnapshot(idxStore);
+    React.useEffect(() => {
+     const getUsers = async (id) => {
+       setUsers()
+     };
+     getUsers(index);
+  }, [index])
+  return <></>
     }
-    `,
+`,
     `
-    const DirectReadComponent = () => {
-      const debounceSnap = useSnapshot(state);
-      return <div>{debounceSnap}</div>;
-    };
-    `,
+	const state = proxy({count:1});
+	const useDoubled = () => {
+		const snap = useSnapshot(state)
+		const doubled = snap.count*2;
+		return doubled 
+	}
+	`,
     `
-    const ObjectPatternReadOne = () => {
-      const {b: {c} } = useSnapshot(state);
-      return <div>{c}</div>;
-    };`,
+	const state = proxy({count:1});
+	const useDoubled = () => {
+		const snap = useSnapshot(state)
+		const {doubled} = {doubled:snap.count*2};
+		return doubled 
+	}
+	`,
     `
-    const ObjectPatternReadTwo = () => {
-      const {c} = useSnapshot(state);
-      return <div>{c}</div>;
-    };`,
+const state = proxy({ count: 0 });
+const App=()=>{
+  const {count} = useSnapshot(state);
+  const doubled = count*2;
+  return (
+    <div>
+      {count} <button onClick={handleClick}>click</button>
+    </div>
+  );
+}
+`,
   ],
   invalid: [
     {
       code: `
-    const state = proxy({ count: 0})
-    function Counter() {
-      const { count } = state
-      return (
-        <div>
-          {state.count} {count}
-          <button onClick={() => ++state.count}>+1</button>
-        </div>
-      )
-    }
-    `,
+     const state = proxy({ count: 0})
+     function Counter() {
+       const { count } = state
+       return (
+         <div>
+           {state.count} {count}
+           <button onClick={() => ++state.count}>+1</button>
+         </div>
+       )
+     }
+     `,
       errors: [PROXY_RENDER_PHASE_MESSAGE, PROXY_RENDER_PHASE_MESSAGE],
     },
     {
       code: `
-    function Counter() {
-      const snapshot = useSnapshot(state)
-      useEffect(() => {
-        ++snapshot.count
-      })
-      return (
-        <div>{snapshot.count}</div>
-      )
-    }
-    `,
+     function Counter() {
+       const snapshot = useSnapshot(state)
+       useEffect(() => {
+         ++snapshot.count
+       })
+       return (
+         <div>{snapshot.count}</div>
+       )
+     }
+     `,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-    function Counter() {
-      const { count } = useSnapshot(state)
-      useEffect(() => {
-        ++count
-      })
-      return (
-        <div>{snapshot.count}</div>
-      )
-    }
-    `,
+     function Counter() {
+       const { count } = useSnapshot(state)
+       useEffect(() => {
+         ++count
+       })
+       return (
+         <div>{snapshot.count}</div>
+       )
+     }
+     `,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-    const state = proxy({ count: 0})
-    function Counter() {
-      const snap = useSnapshot(state)
-      return (
-        <div>
-          {snap.count}
-          <button onClick={() => ++snap.count}>+1</button>
-        </div>
-      )
-    }
-    `,
+     const state = proxy({ count: 0})
+     function Counter() {
+       const snap = useSnapshot(state)
+       return (
+         <div>
+           {snap.count}
+           <button onClick={() => ++snap.count}>+1</button>
+         </div>
+       )
+     }
+     `,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-      function Counter() {
-        const snap = useSnapshot(state.r.b)
-        const snap1 = useSnapshot(state)
-        const handleClick = () => {
-          state.r.b = ['hello', 'ss']
-          state = ['hello']
-        }
-       return <div></div> 
-      }
-      `,
+       function Counter() {
+         const snap = useSnapshot(state.r.b)
+         const snap1 = useSnapshot(state)
+         const handleClick = () => {
+           state.r.b = ['hello', 'ss']
+           state = ['hello']
+         }
+        return <div></div>
+       }
+       `,
       errors: [UNEXPECTED_STATE_MUTATING, UNEXPECTED_STATE_MUTATING],
     },
     {
       code: `
-          function Counter() {
-            const snap = useSnapshot(state)
-            const handleClick = () => {
-              state = ['hello']
-            }
-           return <div></div>
-          }
-          `,
+           function Counter() {
+             const snap = useSnapshot(state)
+             const handleClick = () => {
+               state = ['hello']
+             }
+            return <div></div>
+           }
+           `,
       errors: [UNEXPECTED_STATE_MUTATING],
     },
     {
       code: `
-          function Counter() {
-            const snap = useSnapshot(state.a)
-            const handleClick = () => {
-              state.a = ['hello']
-            }
-           return <div></div>
-          }
-          `,
+           function Counter() {
+             const snap = useSnapshot(state.a)
+             const handleClick = () => {
+               state.a = ['hello']
+             }
+            return <div></div>
+           }
+           `,
       errors: [UNEXPECTED_STATE_MUTATING],
     },
     {
       code: `
-          function Counter() {
-            const snap = useSnapshot(state[0])
-            return <div>{snap}<button onClick={() => ++state[0]}>inc</button></div>
-          }
-          `,
+           function Counter() {
+             const snap = useSnapshot(state[0])
+             return <div>{snap}<button onClick={() => ++state[0]}>inc</button></div>
+           }
+           `,
       errors: [UNEXPECTED_STATE_MUTATING],
     },
     {
       code: `const state = proxyWithComputed({
-      count: 0,
-    }, {
-      quadrupled: (snap) => snap.doubled * 2,
-      doubled: (snap) => snap.count * 2,
-    })
-      `,
+       count: 0,
+     }, {
+       quadrupled: (snap) => snap.doubled * 2,
+       doubled: (snap) => snap.count * 2,
+     })
+       `,
       errors: [COMPUTED_DECLARATION_ORDER],
     },
     {
       code: `const state = proxyWithComputed({
-      count: 0,
-    }, {
-      quadrupled: ({ doubled }) => doubled * 2,
-      doubled: (snap) => snap.count * 2,
-    })
-      `,
+       count: 0,
+     }, {
+       quadrupled: ({ doubled }) => doubled * 2,
+       doubled: (snap) => snap.count * 2,
+     })
+       `,
       errors: [COMPUTED_DECLARATION_ORDER],
     },
     {
       code: `function Counter() {
-      const snapshot = useSnapshot(state)
-      useEffect(() => {
-        snapshot.count = randomValue + 1;
-      })
-      return (
-        <></>
-      )
-    }`,
+       const snapshot = useSnapshot(state)
+       useEffect(() => {
+         snapshot.count = randomValue + 1;
+       })
+       return (
+         <></>
+       )
+     }`,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-          function useProxyStateExample(a) {
-            const s = useSnapshot(a);
-
-            useEffect(() => {
-              if(s.a==="1"){
-                s.a = 'example';
-              }
-            }, [s.a]);
-          }`,
+           function useProxyStateExample(a) {
+             const s = useSnapshot(a);
+             useEffect(() => {
+               if(s.a==="1"){
+                 s.a = 'example';
+               }
+             }, [s.a]);
+           }`,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-
-    function App() {
-      const snap = useSnapshot(state)
-      const handleClick = () => {
-        console.log(snap.count) // This is not recommended as it can be stale.
-      }
-      return (
-        <div>
-           <button onClick={handleClick}>click</button>
-        </div>
-      )
-    }
-
-          `,
+     function App() {
+       const snap = useSnapshot(state)
+       const handleClick = () => {
+         console.log(snap.count) // This is not recommended as it can be stale.
+       }
+       return (
+         <div>
+            <button onClick={handleClick}>click</button>
+         </div>
+       )
+     }
+           `,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-          const state = proxy({ count: 0 })
-
-          function App() {
-            const snap = useSnapshot(state)
-            const handleClick = useCallback(() => {
-              console.log(snap.count) // This is not recommended as it can be stale.
-            },[])
-            return (
-              <div>
-                {snap.count} <button onClick={handleClick}>click</button>
-              </div>
-            )
-          }
-          `,
+           const state = proxy({ count: 0 })
+           function App() {
+             const snap = useSnapshot(state)
+             const handleClick = useCallback(() => {
+               console.log(snap.count) // This is not recommended as it can be stale.
+             },[])
+             return (
+               <div>
+                 {snap.count} <button onClick={handleClick}>click</button>
+               </div>
+             )
+           }
+           `,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `const state = proxy({ count: 0 })
-
-          function App() {
-            const snap = useSnapshot(state)
-            const handleClick = useCallback(() => {
-              console.log(snap.count) // This is not recommended as it can be stale.
-            },[])
-            return (
-              <div>
-                {snap.count} <button onClick={handleClick}>click</button>
-              </div>
-            )
-          }
-    `,
+           function App() {
+             const snap = useSnapshot(state)
+             const handleClick = useCallback(() => {
+               console.log(snap.count) // This is not recommended as it can be stale.
+             },[])
+             return (
+               <div>
+                 {snap.count} <button onClick={handleClick}>click</button>
+               </div>
+             )
+           }
+     `,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
     {
       code: `
-          function useExample2(s) {
-            const {b: {c} } = useSnapshot(s.a1);
-
-            useEffect(() => {
-              if (c === 'a1c') {
-                state.a1.b.c = 'example';
-              }
-            }, []);
-          }`,
+           function useExample2(s) {
+             const {b: {c} } = useSnapshot(s.a1);
+             useEffect(() => {
+               if (c === 'a1c') {
+                 s.a1.b.c = 'example';
+               }
+             }, []);
+           }`,
       errors: [SNAPSHOT_CALLBACK_MESSAGE],
     },
   ],

--- a/tests/StateSnapshot.test.js
+++ b/tests/StateSnapshot.test.js
@@ -150,6 +150,13 @@ const App=()=>{
   );
 }
 `,
+    `
+const useDoubled = ({ state }) => {
+  const snap = useSnapshot(state)
+  const {doubled} = {doubled:snap.count*2};
+  return doubled 
+}
+`,
   ],
   invalid: [
     {


### PR DESCRIPTION
- Added handling for CallExpressions for just reading of snapshots. 
- Simplified the eslint fires for read cases and write cases 
- Adds specific checks for hooks and custom hooks (might need to re-consider) 

Fix: #28 
