### PR TITLE
empty string for flat member expressions, default case addition

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -288,6 +288,7 @@ function flattenMemberExpression(expr, key = '') {
     }
     return path
   }
+  return ''
 }
 
 export function isDepthSameAsRootComponent(node) {


### PR DESCRIPTION
fix: #30 