### PR TITLE
fix TypeError: Cannot read properties of null (reading 'parent') within isInCustomHookDef

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -350,10 +350,19 @@ export function isInCustomHookDef(node) {
     nearestFuncDef,
     'VariableDeclarator'
   )
+
+  if (!varDeclaratorOfFunc) {
+    return false
+  }
+
   const varDefOfFunc = getParentOfNodeType(
     varDeclaratorOfFunc,
     'VariableDeclaration'
   )
+
+  if (!varDefOfFunc) {
+    return false
+  }
 
   const varDefOnRoot = varDefOfFunc.parent?.type === 'Program' || false
 


### PR DESCRIPTION
Hello! I've discovered an issue with `eslint-plugin-valtio` in the following scenario:


```ts
type MyValue = any;
function MyFunction() {
  const id = useSnapshot(store) // normal usage of valtio snapshot
  const [value, setValue] = useState({});
  
  useQuery({
    queryKey: ['test'],
    queryFn: () => {
      setValue(prev) => {
        return {
          ...prevent,
          [id]: value as MyValue //breaks on this line
        }
      }
    },
  });
  
}
```

The error I'm receiving is:
```
TypeError: Cannot read properties of null (reading 'parent')
Occurred while linting MyComponent.tsx:91
Rule: "valtio/state-snapshot-rule"
    at isInCustomHookDef (MyProject/node_modules/eslint-plugin-valtio/index.js:238:60)
    at Identifier (MyProject/node_modules/eslint-plugin-valtio/index.js:346:92)
````